### PR TITLE
Make source buckets configurable

### DIFF
--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Build image
         run: |
-          docker build --tag ${SOURCE_IMAGE}:latest .
+          docker build --quiet --tag ${SOURCE_IMAGE}:latest .
 
       - name: Configure AWS credentials (OIDC)
         # In CI (i.e., not running locally via `act`), use OIDC for credentials

--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -69,8 +69,17 @@ jobs:
               return context.ref.split('/').slice(-1)[0];
             }
 
-            // Return either the pull request number or the git commit short SHA
-            return context.payload.number ?? context.sha.slice(0, 7);
+            // For uniqueness, use the partial SHA of the current commit in the tag
+            // as a suffix to the (zero-padded) PR number.
+
+            const pr = context.payload.number;
+            const partial_sha = context.sha.slice(0, 7);
+
+            // We should always have a PR number since this workflow is triggered
+            // only via release or pull_request, and the release case was handled
+            // above, but for safety, we'll handle the case of a missing PR number.
+
+            return pr ? `pr-${String(pr).padStart(3, '0')}-${partial_sha}` : partial_sha;
 
       - name: Tag and push image to Amazon ECR
         env:

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ following environment variables must/can be set:
 - `GRANULE_ID`: ID of the HLS granule from which to produce the associated HLS
   VI granule files.
 - `LPDAAC_PROTECTED_BUCKET_NAME` (_optional_): Name of the bucket containing
-  ingested HLS granule files (default: `"lp_prod_protected"`).
+  ingested HLS granule files (default: `"lp-prod-protected"`).
 - `LPDAAC_PUBLIC_BUCKET_NAME` (_optional_): Name of the bucket containing
-  HLS thumbnails (`.jpg`) (default: `"lp_prod_public"`) associated with the
+  HLS thumbnails (`.jpg`) (default: `"lp-prod-public"`) associated with the
   granule files in the other bucket.
 - `OUTPUT_BUCKET`: Name of the bucket in which to put the produced HLS VI
   granule files.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ processing.
 
 - [Running a Container](#running-a-container)
 - [Development](#development)
+  - [Running Unit Tests](#running-unit-tests)
   - [Bootstrapping MinIO](#bootstrapping-minio)
   - [Testing the Docker Image](#testing-the-docker-image)
   - [Inspecting MinIO Objects](#inspecting-minio-objects)
@@ -22,6 +23,11 @@ following environment variables must/can be set:
   batch job, so this should be set to the job ID.
 - `GRANULE_ID`: ID of the HLS granule from which to produce the associated HLS
   VI granule files.
+- `LPDAAC_PROTECTED_BUCKET_NAME` (_optional_): Name of the bucket containing
+  ingested HLS granule files (default: `"lp_prod_protected"`).
+- `LPDAAC_PUBLIC_BUCKET_NAME` (_optional_): Name of the bucket containing
+  HLS thumbnails (`.jpg`) (default: `"lp_prod_public"`) associated with the
+  granule files in the other bucket.
 - `OUTPUT_BUCKET`: Name of the bucket in which to put the produced HLS VI
   granule files.
 - `DEBUG_BUCKET` (_optional_): Name of the bucket to use _instead of_
@@ -39,6 +45,14 @@ Prerequisites:
 - Install [Docker Desktop]
 - Install [AWS CLI] (optional, for inspecting S3 objects in your MinIO store)
 - Install [act] (optional, for locally testing Docker image publication GitHub workflow)
+
+### Running Unit Tests
+
+Run unit tests as follows:
+
+```plain
+uv run pytest
+```
 
 ### Bootstrapping MinIO
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -46,4 +46,6 @@ services:
       - AWS_ACCESS_KEY_ID=${MINIO_ROOT_USER:-minioadmin}
       - AWS_SECRET_ACCESS_KEY=${MINIO_ROOT_PASSWORD:-minioadmin}
       - AWS_BATCH_JOB_ID=42
+      - LPDAAC_PUBLIC_BUCKET_NAME
+      - LPDAAC_PROTECTED_BUCKET_NAME
       - OUTPUT_BUCKET=hls-global-v2-forward

--- a/scripts/bootstrap-minio.py
+++ b/scripts/bootstrap-minio.py
@@ -47,6 +47,7 @@ def make_downloader(s3: S3Client) -> Downloader:
     seemlessly use HTTPS to download a file from an LPDAAC bucket to a local
     file, then "upload" the local file to the corresponding local MinIO bucket.
     """
+
     def transfer(src: tuple[str, str], dst: Path) -> None:
         bucket, key = src
         http_download(src, dst)
@@ -85,7 +86,11 @@ def transfer_granule_files(s3: S3Client, granule_id: str) -> None:
     To avoid unnecessary egress costs, only files missing from the local MinIO
     buckets are transferred.
     """
-    sources = granule_sources(granule_id)
+    sources = granule_sources(
+        granule_id,
+        public_bucket="lp-prod-public",
+        protected_bucket="lp-prod-protected",
+    )
 
     with TemporaryDirectory() as tmpdir:
         missing = [source for source in sources if not object_exists(s3, source)]


### PR DESCRIPTION
The source buckets were hard-coded as the LPDAAC Production public and protected buckets. They are now configurable via the `LPDAAC_PUBLIC_BUCKET_NAME` and `LPDAAC_PROTECTED_BUCKET_NAME` environment variables, respectively, defaulting to `lp-prod-public` and `lp-prod-protected`, respectively, if not set.