### PR TITLE
feat: use LPDAAC specific credentials for downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,17 @@ following environment variables must/can be set:
   granule files.
 - LPDAAC AWS Credentials (_optional_): AWS credentials for accessing LPDAAC
   data buckets may be provided.
-    - `LPDAAC_ACCESS_KEY_ID`
-    - `LPDAAC_SECRET_ACCESS_KEY`
-    - `LPDAAC_SESSION_TOKEN`
+  - `LPDAAC_ACCESS_KEY_ID`
+  - `LPDAAC_SECRET_ACCESS_KEY`
+  - `LPDAAC_SESSION_TOKEN`
+  - **Note**: The `hls-vi-historical-orchestration` system injects these environment
+    variables into this container when running AWS Batch jobs.
+    This works by defining "secrets" in the JobDefinition's configuration settings
+    that instruct the AWS Batch worker to pull from SecretsManager and pass the values
+    as environment variables when running the container.
+    Since these S3 credentials expire after 1 hour, a scheduled Lambda function refreshes
+    the value of the secret with new credentials provided by the LPDAAC `/s3credentials`
+    endpoint.
 - `DEBUG_BUCKET` (_optional_): Name of the bucket to use _instead of_
   `OUTPUT_BUCKET`, so that the produced outputs can be inspected for debugging
   purposes, without triggering LPDAAC notification.

--- a/README.md
+++ b/README.md
@@ -228,3 +228,9 @@ file in order for `act` to be able to reference your Docker Desktop socket:
   https://search.earthdata.nasa.gov/search/granules?p=C2021957657-LPCLOUD
 [S30]:
   https://search.earthdata.nasa.gov/search/granules?p=C2021957295-LPCLOUD
+[hls-vi-historical-orchestration]:
+  https://github.com/NASA-IMPACT/hls-vi-historical-orchestration
+[LPDAAC S3 credentials endpoint]:
+  https://data.lpdaac.earthdatacloud.nasa.gov/s3credentials
+[NASA Earthdata Login]:
+  https://urs.earthdata.nasa.gov/

--- a/README.md
+++ b/README.md
@@ -32,17 +32,19 @@ following environment variables must/can be set:
   granule files.
 - LPDAAC AWS Credentials (_optional_): AWS credentials for accessing LPDAAC
   data buckets may be provided.
+
   - `LPDAAC_ACCESS_KEY_ID`
   - `LPDAAC_SECRET_ACCESS_KEY`
   - `LPDAAC_SESSION_TOKEN`
-  - **Note**: The `hls-vi-historical-orchestration` system injects these environment
-    variables into this container when running AWS Batch jobs.
-    This works by defining "secrets" in the JobDefinition's configuration settings
-    that instruct the AWS Batch worker to pull from SecretsManager and pass the values
-    as environment variables when running the container.
-    Since these S3 credentials expire after 1 hour, a scheduled Lambda function refreshes
-    the value of the secret with new credentials provided by the LPDAAC `/s3credentials`
-    endpoint.
+
+  Values are obtained via a request to the [LPDAAC S3 credentials endpoint].
+  Such a request requires a [NASA Earthdata Login] account.
+
+  These are optional in accounts that have been granted direct read permission
+  to the LPDAAC protected bucket.
+
+  **NOTE**: The [hls-vi-historical-orchestration] system injects these
+  environment variables into this container when running AWS Batch jobs.
 - `DEBUG_BUCKET` (_optional_): Name of the bucket to use _instead of_
   `OUTPUT_BUCKET`, so that the produced outputs can be inspected for debugging
   purposes, without triggering LPDAAC notification.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ following environment variables must/can be set:
   granule files in the other bucket.
 - `OUTPUT_BUCKET`: Name of the bucket in which to put the produced HLS VI
   granule files.
+- LPDAAC AWS Credentials (_optional_): AWS credentials for accessing LPDAAC
+  data buckets may be provided.
+    - `LPDAAC_ACCESS_KEY_ID`
+    - `LPDAAC_SECRET_ACCESS_KEY`
+    - `LPDAAC_SESSION_TOKEN`
 - `DEBUG_BUCKET` (_optional_): Name of the bucket to use _instead of_
   `OUTPUT_BUCKET`, so that the produced outputs can be inspected for debugging
   purposes, without triggering LPDAAC notification.

--- a/hls_vi_historical/main.py
+++ b/hls_vi_historical/main.py
@@ -373,10 +373,17 @@ def main() -> None:
     output_dir = working_dir / "hls-vi"
     output_dir.mkdir(parents=True, exist_ok=True)
 
+    lpdaac_session = boto3.Session(
+        aws_access_key_id=os.getenv("LPDAAC_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.getenv("LPDAAC_SECRET_ACCESS_KEY"),
+        aws_session_token=os.getenv("LPDAAC_SESSION_TOKEN"),
+    )
+    lpdaac_s3 = lpdaac_session.client("s3")
+
     s3 = boto3.client("s3")
 
     prepare_inputs(
-        s3,
+        lpdaac_s3,
         granule_id,
         input_dir,
         public_bucket=public_bucket,


### PR DESCRIPTION
This PR adds support for defining a LPDAAC-specific set of AWS credentials that will be used for downloading imagery. This PR is needed to support using the `s3credentials` endpoint for accessing HLS outputs in lieu of having our container's IAM policy be allowed access directly.

I grabbed the environment variables via `os.getenv` because we might want to revert using specific S3 credentials and fall back to the instance role without changing this container. We can do this by no longer providing these environment variables from the `hls-vi-historical-orchestration` code.