### PR TITLE
fix: indicate request payer is requester

### DIFF
--- a/hls_vi_historical/main.py
+++ b/hls_vi_historical/main.py
@@ -115,7 +115,9 @@ def make_s3_downloader(s3: S3Client) -> Downloader:
         print(f"Downloading s3://{bucket}/{key} to {dst}")
 
         try:
-            s3.download_file(bucket, key, str(dst))
+            s3.download_file(
+                bucket, key, str(dst), ExtraArgs={"RequestPayer": "requester"}
+            )
         except botocore.exceptions.ClientError:
             msg = f"Failed to download s3://{bucket}/{key}"
             raise RuntimeError(msg)


### PR DESCRIPTION
## Description

This PR adds the "requester pays for request" flag to our download calls. This is to enable direct bucket access without using the temporary credentials from LPDAAC's `/s3credentials` endpoint.

We've just been approved and our IAM roles have been added to bucket policy, so we should be good to switch over to direct bucket access with "requester pays for requests"